### PR TITLE
remove object user only for cadastroProduto

### DIFF
--- a/src/models/Produto.ts
+++ b/src/models/Produto.ts
@@ -9,5 +9,5 @@ export interface Produto {
     descricao: string;
     data: string;
     categoria?: Categoria | null
-    // usuario?: User | null
+    usuario?: User | null
 }


### PR DESCRIPTION
o objeto usuario estava interferindo no cadastro de produto, poís deu que o id não era um número.